### PR TITLE
Fix property setters causing recursion

### DIFF
--- a/scripts/enemy_slime.gd
+++ b/scripts/enemy_slime.gd
@@ -12,10 +12,13 @@ enum MaxDistanceType {RELATIVE, GLOBAL}
 @onready var kill_timer: Timer = $KillTimer
 @onready var death_sound: AudioStreamPlayer2D = $DeathSound
 
+var _sprite_frames: SpriteFrames
 @export var sprite_frames: SpriteFrames:
-	set(value):
-		sprite_frames = value
-		_apply_sprite_frames()
+       set(value):
+               _sprite_frames = value
+               _apply_sprite_frames()
+       get:
+               return _sprite_frames
 
 @export var max_distance_type := MaxDistanceType.RELATIVE
 @export var max_distance := 1000.0

--- a/scripts/platform_big.gd
+++ b/scripts/platform_big.gd
@@ -5,10 +5,13 @@ extends StaticBody2D
 @onready var collision_shape: CollisionShape2D = $CollisionShape
 @onready var monitoring_area: Area2D = $MonitoringArea
 
+var _sprite_texture: Texture2D
 @export var sprite_texture: Texture2D:
-	set(value):
-		sprite_texture = value
-		_apply_sprite_texture()
+       set(value):
+               _sprite_texture = value
+               _apply_sprite_texture()
+       get:
+               return _sprite_texture
 
 
 func _ready():


### PR DESCRIPTION
## Summary
- fix sprite frame setter in `EnemySlime` to avoid infinite recursion
- fix sprite texture setter in `PlatformBig` with backing variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f80e66928832e9a819d1761e74ecb