### PR TITLE
Add AI conventions and refine architecture docs

### DIFF
--- a/.aidocs/aidocs-guidelines.md
+++ b/.aidocs/aidocs-guidelines.md
@@ -1,4 +1,4 @@
-# aidocs-guidelines
+# aidocs-guidelines.md
 
 This folder stores persistent AI-facing documentation. Each file should cover a single topic so assistants can load only what they need.
 

--- a/.aidocs/aidocs-guidelines.md
+++ b/.aidocs/aidocs-guidelines.md
@@ -18,3 +18,11 @@ This folder stores persistent AI-facing documentation. Each file should cover a 
 - When modifying existing docs or adding new ones, also update `AGENTS.md` with a brief description of each file.
 - Ensure new docs respect Aider conventions and [Anthropic code best practices](https://www.anthropic.com/engineering/claude-code-best-practices) for clarity and maintainability.
 
+## Coordination with AGENTS.md
+- `AGENTS.md` defines high-level intent, principles, and the role of AI in the project.
+- `.aidocs/` contains detailed and topic-specific supporting documentation.
+- When moving any content from `AGENTS.md` to `.aidocs/`, always:
+  - Remove the original section from `AGENTS.md`.
+  - Optionally leave a brief cross-reference if needed.
+  - Ensure `.aidocs/` fully captures the removed content in context.
+

--- a/.aidocs/aidocs-guidelines.md
+++ b/.aidocs/aidocs-guidelines.md
@@ -1,0 +1,20 @@
+# aidocs-guidelines
+
+This folder stores persistent AI-facing documentation. Each file should cover a single topic so assistants can load only what they need.
+
+## Creating new docs
+- Use **Markdown** with lower-case kebab-case filenames.
+- Keep each document self-contained. Do not rely on reading other `/.aidocs/` files to understand it.
+- Summarize intent, architecture and style in short sections. Favor lists and short paragraphs over long prose.
+- Mirror the tone of the codebase: clear, direct and free of unnecessary jargon.
+
+## Content principles
+- Follow the style and architecture rules in [AGENTS.md](../AGENTS.md).
+- Document the _why_ behind patterns so AI tools can reason about decisions.
+- Prefer concrete examples from the code when useful.
+- Keep sections focused; break large subjects into multiple files.
+
+## Updates
+- When modifying existing docs or adding new ones, also update `AGENTS.md` with a brief description of each file.
+- Ensure new docs respect Aider conventions and [Anthropic code best practices](https://www.anthropic.com/engineering/claude-code-best-practices) for clarity and maintainability.
+

--- a/.aidocs/architecture.md
+++ b/.aidocs/architecture.md
@@ -1,0 +1,16 @@
+# architecture
+
+This document outlines the directory layout and how the pieces fit together.
+It captures design intent so assistants can understand where new files belong.
+
+## Top-level directories
+- **assets/** – static game assets: sprites, sounds, fonts. No scripts live here.
+- **scenes/** – reusable scenes and level data. `scenes/core` holds common building blocks while `scenes/levels` contains individual stages.
+- **scripts/** – gameplay logic and utilities. `scripts/core` stores foundational nodes and helpers used across the project.
+- **resources/** – data assets and script resources referenced via exported properties.
+- **editor/** – icons and tools used inside the Godot editor.
+
+`project.godot` defines engine settings and points to the above directories.
+Scenes reference scripts under `scripts/`, and scripts rely on resources for
+configuration. Keeping these directories separate allows clearer dependencies
+and simplifies extending the game.

--- a/.aidocs/architecture.md
+++ b/.aidocs/architecture.md
@@ -18,6 +18,7 @@ and simplifies extending the game.
 
 ## Directory tree
 
+```
 .
 ├── assets
 │   ├── fonts
@@ -38,3 +39,48 @@ and simplifies extending the game.
             │   ├── 2d
             │   └── tools
             └── resources
+```
+
+## Directory descriptions
+
+### `assets/`
+Artwork and audio used by the game, subdivided into fonts, background music, sound effects, and sprite images.
+
+- **`fonts/`** – Pixel-style typefaces for UI and in-game text
+- **`music/`** – Background soundtrack files (e.g., `time_for_adventure.mp3`)
+- **`sounds/`** – Sound effects such as coin collection and jumping
+- **`sprites/`** – PNG images for characters, platforms, and other visual elements
+
+---
+
+### `editor/`
+Assets supporting custom editor tooling; currently only icon graphics.
+
+- **`icons/`** – SVG icons displayed in the Godot editor for specialized tools
+
+---
+
+### `resources/`
+Reusable Godot resource files (textures, shapes, strategy resources) shared across scenes.
+
+- **`core/`** – Foundational resources like collision shapes and boundary definitions
+
+---
+
+### `scenes/`
+Godot `.tscn` scenes defining gameplay objects and levels.
+
+- **`core/`** – Core scene templates for triggers, level entry/exit, abyss boundaries, etc.
+- **`levels/`** – Complete playable level scenes (e.g., `level_0.tscn`, `level_1.tscn`)
+
+---
+
+### `scripts/`
+GDScript source code powering gameplay and utilities.
+
+- **`core/`** – Central gameplay logic and framework components
+    - **`objects/`** – Reusable object implementations split into nodes and resource classes
+        - **`nodes/`** – Scripted nodes for gameplay entities and systems
+            - **`2d/`** – 2D-specific nodes like `Collectable2D`, `Hitbox2D`, and spawn points
+            - **`tools/`** – Node-based editor tools for level design and debugging
+        - **`resources/`** – Resource classes such as scoring or collectable strategies  

--- a/.aidocs/architecture.md
+++ b/.aidocs/architecture.md
@@ -14,3 +14,26 @@ It captures design intent so assistants can understand where new files belong.
 Scenes reference scripts under `scripts/`, and scripts rely on resources for
 configuration. Keeping these directories separate allows clearer dependencies
 and simplifies extending the game.
+
+## Tree
+
+.
+├── assets
+│   ├── fonts
+│   ├── music
+│   ├── sounds
+│   └── sprites
+├── editor
+│   └── icons
+├── resources
+│   └── core
+├── scenes
+│   ├── core
+│   └── levels
+└── scripts
+    └── core
+        └── objects
+            ├── nodes
+            │   ├── 2d
+            │   └── tools
+            └── resources

--- a/.aidocs/architecture.md
+++ b/.aidocs/architecture.md
@@ -1,21 +1,22 @@
-# architecture
+# architecture.md
 
 This document outlines the directory layout and how the pieces fit together.
 It captures design intent so assistants can understand where new files belong.
 
 ## Top-level directories
+
 - **assets/** – static game assets: sprites, sounds, fonts. No scripts live here.
+- **editor/** – icons and tools used inside the Godot editor.
+- **resources/** – data assets and script resources referenced via exported properties.
 - **scenes/** – reusable scenes and level data. `scenes/core` holds common building blocks while `scenes/levels` contains individual stages.
 - **scripts/** – gameplay logic and utilities. `scripts/core` stores foundational nodes and helpers used across the project.
-- **resources/** – data assets and script resources referenced via exported properties.
-- **editor/** – icons and tools used inside the Godot editor.
 
 `project.godot` defines engine settings and points to the above directories.
 Scenes reference scripts under `scripts/`, and scripts rely on resources for
 configuration. Keeping these directories separate allows clearer dependencies
 and simplifies extending the game.
 
-## Tree
+## Directory tree
 
 .
 ├── assets

--- a/.aidocs/conventions.md
+++ b/.aidocs/conventions.md
@@ -1,4 +1,4 @@
-# conventions
+# conventions.md
 
 This file captures execution and style conventions that are not obvious from code alone.
 

--- a/.aidocs/conventions.md
+++ b/.aidocs/conventions.md
@@ -1,0 +1,15 @@
+# conventions
+
+This file captures execution and style conventions that are not obvious from code alone.
+
+## Safe execution & deferral
+- Prefer the type-safe form of `call_deferred`:
+  ```gdscript
+  method.call_deferred()
+  ```
+  Avoid the string-based form `call_deferred("method")` to ensure refactors remain safe.
+
+## General approach
+- Use Godot's built-in nodes and signals before adding custom layers.
+- Keep scripts focused on one responsibility and expose properties with `@export`.
+- Rely on signals for loose coupling between nodes.

--- a/.aidocs/nodes.md
+++ b/.aidocs/nodes.md
@@ -1,4 +1,4 @@
-# nodes
+# nodes.md
 
 Custom node scripts live under `scripts/core/objects/nodes`. They provide reusable behaviors that extend Godot's standard nodes.
 

--- a/.aidocs/nodes.md
+++ b/.aidocs/nodes.md
@@ -1,0 +1,16 @@
+# nodes
+
+Custom node scripts live under `scripts/core/objects/nodes`. They provide reusable behaviors that extend Godot's standard nodes.
+
+## Naming
+- Files use `PascalCase` names ending with the node type (e.g. `Hitbox2D.gd`).
+- Each script starts with `class_name` so it can be attached in the editor.
+
+## Examples
+- `Level2D.gd` manages camera limits and emits signals when the player exits.
+- `Hitbox2D.gd` and `Hurtbox2D.gd` implement attack and damage areas.
+- `SpawnManager.gd` spawns new instances of scenes at runtime.
+
+## Usage
+- Nodes are intended to be instanced in scenes and wired together using signals.
+- Properties are exported so level designers can adjust them without editing code.

--- a/.aidocs/resources.md
+++ b/.aidocs/resources.md
@@ -1,0 +1,15 @@
+# resources
+
+Resource scripts and data files provide tunable gameplay parameters. They are stored under `scripts/core/objects/resources` and `resources/`.
+
+## Script resources
+- Strategy scripts such as `CollectableStrategy.gd` and `ScoreStrategy.gd` define behaviors that can be swapped in the editor.
+- They use `class_name` so they show up in the resource picker.
+
+## Data resources
+- `.tres` files in `resources/` hold shapes, sprite frames and other configuration data.
+- These files are referenced by scenes and scripts via exported properties.
+
+## Purpose
+- Separating data from code lets designers adjust gameplay without changing scripts.
+- Scriptable strategies encourage clean extension of features like scoring or item collection.

--- a/.aidocs/resources.md
+++ b/.aidocs/resources.md
@@ -1,4 +1,4 @@
-# resources
+# resources.md
 
 Resource scripts and data files provide tunable gameplay parameters. They are stored under `scripts/core/objects/resources` and `resources/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@ It is an educational project focused on code quality, architectural clarity, and
 
 ## Agent Instructions
 
-Automated assistants working on this repository should follow these principles:
+This document defines high-level principles and expectations for automated assistants working on this repository.
+It provides strategic intent, while detailed topic-specific guidance is moved to `.aidocs/`.
+
+Assistants should follow the principles below and consult `.aidocs/` for implementation-level conventions:
 
 ### Language & Formatting
 - Use **GDScript 2.0** syntax and features.
@@ -31,8 +34,8 @@ Automated assistants working on this repository should follow these principles:
 
 ### `.aidocs` Reference
 The `/.aidocs/` folder stores persistent AI-facing documents. Each file is self-contained and describes one subject:
-- **aidocs-guidelines.md** – instructions on writing and updating AI documentation.
-- **architecture.md** – an overview of the directory layout and how scenes, scripts, and resources relate to one another.
-- **nodes.md** – conventions for custom node scripts under `scripts/core/objects/nodes`.
-- **resources.md** – when and how resource scripts or `.tres` data files are used.
-- **conventions.md** – safe execution practices and other project‑wide standards.
+- [**aidocs-guidelines.md**](./.aidocs/aidocs-guidelines.md) – instructions on writing and updating AI documentation.
+- [**architecture.md**](./.aidocs/architecture.md) – an overview of the directory layout and how scenes, scripts, and resources relate to one another.
+- [**nodes.md**](./.aidocs/nodes.md) – conventions for custom node scripts under `/scripts/core/objects/nodes`.
+- [**resources.md**](./.aidocs/resources.md) – conventions for custom resource scripts under `/scripts/core/objects/resources`.
+- [**conventions.md**](./.aidocs/conventions.md) – safe execution practices and other project‑wide standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,11 @@ Automated assistants working on this repository should follow these principles:
 - Prefer clear, intention-revealing code and comments. Assistants will mirror the tone and style of the codebase.
 - Keep changes minimal and well-scoped. Assistants work best when given clear, constrained goals.
 - Document key architectural concepts in a way that persistent-memory AIs can reference and align with over time.
+
+### `.aidocs` Reference
+The `/.aidocs/` folder stores persistent AI-facing documents. Each file is self-contained:
+- **aidocs-guidelines.md** – how to create and update AI documentation.
+- **architecture.md** – explains directory layout and how scenes, scripts and resources connect.
+- **nodes.md** – conventions for custom node scripts in `scripts/core/objects/nodes`.
+- **resources.md** – explanation of resource scripts and data files.
+- **conventions.md** – safe execution patterns and other project-wide practices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+## Project Overview
+
+This repository contains a 2D side-scrolling platformer developed with **Godot 4.4** using **GDScript 2.0**.
+It is an educational project focused on code quality, architectural clarity, and using Godot’s native features effectively.
+
+## Agent Instructions
+
+Automated assistants working on this repository should follow these principles:
+
+### Language & Formatting
+- Use **GDScript 2.0** syntax and features.
+- Use **tabs** for indentation (not spaces).
+
+### Code Style & Design
+- Code must be **readable**, **self-documenting**, and **extensible**.
+- Favor **minimal, direct, and focused** changes when fixing or refactoring.
+- Avoid introducing unnecessary abstractions or layers of complexity.
+
+### Architecture & Engine Usage
+- Prefer **Godot's built-in systems** where appropriate.
+- Avoid tight coupling between components. Apply **separation of concerns**.
+- Follow and preserve the architectural decisions already present in the project.
+- Do not use deprecated APIs from Godot 3.x or early 4.x releases.
+
+### Safe Execution & Deferral
+- When using `call_deferred`, prefer the **type-safe form**:
+  ```gdscript
+  method.call_deferred()
+  ```
+  instead of:
+  ```gdscript
+  call_deferred("method")
+  ```
+
+### Documentation & AI Collaboration
+- Maintain concise, structured documentation (e.g., in Markdown) describing architecture, key workflows, and intent.
+- AI assistants rely on this documentation to understand *why* code exists, not just *how* it works.
+- Prefer clear, intention-revealing code and comments. Assistants will mirror the tone and style of the codebase.
+- Keep changes minimal and well-scoped. Assistants work best when given clear, constrained goals.
+- Document key architectural concepts in a way that persistent-memory AIs can reference and align with over time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,16 +22,6 @@ Automated assistants working on this repository should follow these principles:
 - Follow and preserve the architectural decisions already present in the project.
 - Do not use deprecated APIs from Godot 3.x or early 4.x releases.
 
-### Safe Execution & Deferral
-- When using `call_deferred`, prefer the **type-safe form**:
-  ```gdscript
-  method.call_deferred()
-  ```
-  instead of:
-  ```gdscript
-  call_deferred("method")
-  ```
-
 ### Documentation & AI Collaboration
 - Maintain concise, structured documentation (e.g., in Markdown) describing architecture, key workflows, and intent.
 - AI assistants rely on this documentation to understand *why* code exists, not just *how* it works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ Automated assistants working on this repository should follow these principles:
 - Document key architectural concepts in a way that persistent-memory AIs can reference and align with over time.
 
 ### `.aidocs` Reference
-The `/.aidocs/` folder stores persistent AI-facing documents. Each file is self-contained:
-- **aidocs-guidelines.md** – how to create and update AI documentation.
-- **architecture.md** – explains directory layout and how scenes, scripts and resources connect.
-- **nodes.md** – conventions for custom node scripts in `scripts/core/objects/nodes`.
-- **resources.md** – explanation of resource scripts and data files.
-- **conventions.md** – safe execution patterns and other project-wide practices.
+The `/.aidocs/` folder stores persistent AI-facing documents. Each file is self-contained and describes one subject:
+- **aidocs-guidelines.md** – instructions on writing and updating AI documentation.
+- **architecture.md** – an overview of the directory layout and how scenes, scripts, and resources relate to one another.
+- **nodes.md** – conventions for custom node scripts under `scripts/core/objects/nodes`.
+- **resources.md** – when and how resource scripts or `.tres` data files are used.
+- **conventions.md** – safe execution practices and other project‑wide standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,6 @@ Assistants should follow the principles below and consult `.aidocs/` for impleme
 The `/.aidocs/` folder stores persistent AI-facing documents. Each file is self-contained and describes one subject:
 - [**aidocs-guidelines.md**](./.aidocs/aidocs-guidelines.md) – instructions on writing and updating AI documentation.
 - [**architecture.md**](./.aidocs/architecture.md) – an overview of the directory layout and how scenes, scripts, and resources relate to one another.
+- [**conventions.md**](./.aidocs/conventions.md) – safe execution practices and other project‑wide standards.
 - [**nodes.md**](./.aidocs/nodes.md) – conventions for custom node scripts under `/scripts/core/objects/nodes`.
 - [**resources.md**](./.aidocs/resources.md) – conventions for custom resource scripts under `/scripts/core/objects/resources`.
-- [**conventions.md**](./.aidocs/conventions.md) – safe execution practices and other project‑wide standards.


### PR DESCRIPTION
## Summary
- overhaul `architecture.md` to focus on directory layout
- add `conventions.md` for safe execution patterns
- reference new docs in `AGENTS.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fdfe6b8e0832e81a88b3a3a451ba7